### PR TITLE
manual memmap handling

### DIFF
--- a/packages/spectra_inspector/src/spectra_inspector/pages/inspector.py
+++ b/packages/spectra_inspector/src/spectra_inspector/pages/inspector.py
@@ -634,6 +634,7 @@ def export_summary(
         (Output(_dataExportIDS.exportsummary, "disabled"), True, False),
         (Output(_dataExportIDS.exportmsa, "disabled"), True, False),
     ],
+    prevent_initial_call=True,
 )
 def update_graph_figure(
     n_clicks: list[int | None],

--- a/packages/spectra_inspector_server/pyproject.toml
+++ b/packages/spectra_inspector_server/pyproject.toml
@@ -150,6 +150,7 @@ ignore = [
   "PLR2004", # Magic value used in comparison
   "PTH123",  # replace open() with Path.open()
   "PD015",   # pandas Use `df.merge` instead of `pd.merge`
+  "RET504",  # unnecesarry-assign
 ]
 # Uncomment if using a _compat.typing backport
 # typing-modules = ["spectra_inspector_server._compat.typing"]

--- a/packages/spectra_inspector_server/src/spectra_inspector_server/_file_tree_handling.py
+++ b/packages/spectra_inspector_server/src/spectra_inspector_server/_file_tree_handling.py
@@ -60,7 +60,7 @@ class EDAXPathHandler:
 
         return EDAX_file_set(**fullfiles)
 
-    def load_edax(self, sample_name: str) -> EDAX_raw_ds:
+    def load_edax(self, sample_name: str, metadata_only: bool = False) -> EDAX_raw_ds:
         if sample_name in _on_disc_mock.filenames:
             # a short-circuit for testing
             return _on_disc_mock.load(sample_name)
@@ -70,7 +70,7 @@ class EDAXPathHandler:
         if files is None:
             # fallback to guessing
             files = self.get_sample_edax_file_names(sample_name)
-        return load_edax_spd(files)
+        return load_edax_spd(files, metadata_only=metadata_only)
 
 
 __all__ = ["EDAXPathHandler"]

--- a/packages/spectra_inspector_server/src/spectra_inspector_server/model.py
+++ b/packages/spectra_inspector_server/src/spectra_inspector_server/model.py
@@ -117,7 +117,7 @@ class CombinedMetadata(BaseModel):
 
 
 class EDAX_raw_ds:
-    data: npt.NDArray[np.int64]
+    data: npt.NDArray[np.int64] | None
     axes: list[EDAX_axis]
     metadata: dict[str, Any]
     original_metadata: dict[str, Any]
@@ -126,9 +126,7 @@ class EDAX_raw_ds:
     def __init__(self, raw_ds: dict[str, Any]):
 
         axes = [EDAX_axis(**ax_dict) for ax_dict in raw_ds["axes"]]
-
-        valid_data: npt.NDArray[np.int64] = raw_ds["data"]
-        self.data = valid_data
+        self.data = raw_ds.get("data")
         self.axes = axes
         self.metadata = raw_ds["metadata"]
         self.original_metadata = raw_ds["original_metadata"]

--- a/packages/spectra_inspector_server/src/spectra_inspector_server/processor/file_loaders.py
+++ b/packages/spectra_inspector_server/src/spectra_inspector_server/processor/file_loaders.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 from rsciio import edax
 
@@ -5,13 +6,46 @@ from spectra_inspector_server._logging import spectraLogger
 from spectra_inspector_server.model import EDAX_file_set, EDAX_raw_ds
 
 
-def load_edax_spd(edax_files: EDAX_file_set) -> EDAX_raw_ds:
-    ds = edax.file_reader(edax_files.spd, ipr_fname=edax_files.ipr)
+def load_edax_spd_metadata(edax_files: EDAX_file_set) -> dict[str, str]:
+    # load the metadata, always use lazy load
+    ds = edax.file_reader(edax_files.spd, ipr_fname=edax_files.ipr, lazy=True)
     if len(ds) > 1:
         msg = f"The following EDAX file includes more than one ds object, only the first will be loaded: {edax_files.spd}"
         spectraLogger.info(msg)
 
-    return EDAX_raw_ds(ds[0])
+    return {
+        "axes": ds[0]["axes"],
+        "metadata": ds[0]["metadata"],
+        "original_metadata": ds[0]["original_metadata"],
+    }
+
+
+def load_spd_into_memmap(header: dict, spd_path: str) -> np.memmap:
+    # rsciio replaced plain np.memmap with a dask-wrapped memmap. for now,
+    # using a plain memmap to avoid dask dependency within fastapi.
+
+    nx = header["nPoints"]
+    ny = header["nLines"]
+    nCh = header["nChannels"]
+    offset = header["dataOffset"]
+    nbytes = str(header["countBytes"])
+    data_type = {"1": "u1", "2": "u2", "4": "u4"}[nbytes]
+
+    with open(spd_path) as f:
+        # Read data from file into a numpy memmap object
+        data = np.memmap(f, mode="r", offset=offset, dtype=data_type)
+    return data.squeeze().reshape((nx, ny, nCh), order="F")
+
+
+def load_edax_spd(
+    edax_files: EDAX_file_set, metadata_only: bool = False
+) -> EDAX_raw_ds:
+    md = load_edax_spd_metadata(edax_files)
+    if metadata_only:
+        return EDAX_raw_ds(md)
+    data = load_spd_into_memmap(md["original_metadata"]["spd_header"], edax_files.spd)
+    md.update({"data": data})
+    return EDAX_raw_ds(md)
 
 
 def find_data_start(msa_path: str) -> int:

--- a/packages/spectra_inspector_server/src/spectra_inspector_server/processor/file_loaders.py
+++ b/packages/spectra_inspector_server/src/spectra_inspector_server/processor/file_loaders.py
@@ -1,4 +1,7 @@
+from typing import Any
+
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 from rsciio import edax
 
@@ -6,7 +9,7 @@ from spectra_inspector_server._logging import spectraLogger
 from spectra_inspector_server.model import EDAX_file_set, EDAX_raw_ds
 
 
-def load_edax_spd_metadata(edax_files: EDAX_file_set) -> dict[str, str]:
+def load_edax_spd_metadata(edax_files: EDAX_file_set) -> dict[str, Any]:
     # load the metadata, always use lazy load
     ds = edax.file_reader(edax_files.spd, ipr_fname=edax_files.ipr, lazy=True)
     if len(ds) > 1:
@@ -20,7 +23,9 @@ def load_edax_spd_metadata(edax_files: EDAX_file_set) -> dict[str, str]:
     }
 
 
-def load_spd_into_memmap(header: dict, spd_path: str) -> np.memmap:
+def load_spd_into_memmap(
+    header: dict[str, Any], spd_path: str
+) -> npt.NDArray[np.int64]:
     # rsciio replaced plain np.memmap with a dask-wrapped memmap. for now,
     # using a plain memmap to avoid dask dependency within fastapi.
 
@@ -33,8 +38,11 @@ def load_spd_into_memmap(header: dict, spd_path: str) -> np.memmap:
 
     with open(spd_path) as f:
         # Read data from file into a numpy memmap object
-        data = np.memmap(f, mode="r", offset=offset, dtype=data_type)
-    return data.squeeze().reshape((nx, ny, nCh), order="F")
+        data: npt.NDArray[np.int64] = np.memmap(
+            f, mode="r", offset=offset, dtype=data_type
+        )  # type: ignore[call-overload]
+    data = data.squeeze().reshape((nCh, nx, ny), order="F").T
+    return data
 
 
 def load_edax_spd(
@@ -43,7 +51,9 @@ def load_edax_spd(
     md = load_edax_spd_metadata(edax_files)
     if metadata_only:
         return EDAX_raw_ds(md)
-    data = load_spd_into_memmap(md["original_metadata"]["spd_header"], edax_files.spd)
+    data = load_spd_into_memmap(
+        md["original_metadata"]["spd_header"], str(edax_files.spd)
+    )
     md.update({"data": data})
     return EDAX_raw_ds(md)
 

--- a/packages/spectra_inspector_server/src/spectra_inspector_server/processor/operations.py
+++ b/packages/spectra_inspector_server/src/spectra_inspector_server/processor/operations.py
@@ -264,16 +264,16 @@ class OperationEDAXStateHandler:
 
     def get_refined_metadata(self, sample_name: str) -> MetadataModel:
         self._require_sample(sample_name)
-        fl = self.ph.load_edax(sample_name)
+        fl = self.ph.load_edax(sample_name, metadata_only=True)
         return fl.refined_metadata
 
     def get_combined_metadata(self, sample_name: str) -> CombinedMetadata:
         self._require_sample(sample_name)
-        fl = self.ph.load_edax(sample_name)
+        fl = self.ph.load_edax(sample_name, metadata_only=True)
         mm = fl.refined_metadata
 
         axes = fl.axes_by_index
-        shp = fl.data.shape
+        shp = tuple(axes[axid].size for axid in range(3))
         assert len(shp) == 3
 
         return CombinedMetadata(metadata=mm, axes_by_index=axes, data_shape=shp)

--- a/packages/spectra_inspector_server/src/spectra_inspector_server/processor/operations.py
+++ b/packages/spectra_inspector_server/src/spectra_inspector_server/processor/operations.py
@@ -116,15 +116,11 @@ class OperationEDAXStateHandler:
             msg = f"data is None for sample {sample_name}"
             raise ValueError(msg)
 
-        im_subset: npt.NDArray[np.int64] = (
-            edax_ds.data[
-                slice(valid_index_ranges[0][0], valid_index_ranges[0][1]),
-                slice(valid_index_ranges[1][0], valid_index_ranges[1][1]),
-                channel_slice,
-            ]
-            .copy()
-            .astype(np.int64)
-        )
+        im_subset: npt.NDArray[np.int64] = edax_ds.data[
+            slice(valid_index_ranges[0][0], valid_index_ranges[0][1]),
+            slice(valid_index_ranges[1][0], valid_index_ranges[1][1]),
+            channel_slice,
+        ]
         return im_subset
 
     def get_raveled_multi_channel_intensity_image(
@@ -199,7 +195,6 @@ class OperationEDAXStateHandler:
                 msg = f"data is None for sample {sample_name}"
                 raise ValueError(msg)
             im_subset = np.sum(edax_ds.data[data_slices], axis=-1, dtype=np.int64)
-            im_subset = im_subset.astype(np.int64).copy()
             slcs = [
                 slice(
                     index_ranges[idim][0] - index_offsets[idim],

--- a/packages/spectra_inspector_server/src/spectra_inspector_server/processor/operations.py
+++ b/packages/spectra_inspector_server/src/spectra_inspector_server/processor/operations.py
@@ -13,6 +13,8 @@ from spectra_inspector_server.model import (
 )
 from spectra_inspector_server.processor.utilities import _make_serializeable_dict
 
+_DEFAULT_CHUNKSIZE = 128
+
 
 class OperationEDAXStateHandler:
     def __init__(self, ph: EDAXPathHandler, allow_mock_files: bool = False) -> None:
@@ -89,6 +91,7 @@ class OperationEDAXStateHandler:
         channel_index: int | tuple[int, int],
         index0_range: tuple[int, int] | None = None,
         index1_range: tuple[int, int] | None = None,
+        edax_ds: Any | None = None,
     ) -> npt.NDArray[np.int64]:
 
         self._require_sample(sample_name)
@@ -106,7 +109,13 @@ class OperationEDAXStateHandler:
             msg = f"unexpected type for channel_index: must be int or (int, int), but {channel_index=}"  # type:ignore[unreachable]
             raise TypeError(msg)
 
-        edax_ds = self.ph.load_edax(sample_name)
+        if edax_ds is None:
+            edax_ds = self.ph.load_edax(sample_name)
+
+        if edax_ds.data is None:
+            msg = f"data is None for sample {sample_name}"
+            raise ValueError(msg)
+
         im_subset: npt.NDArray[np.int64] = (
             edax_ds.data[
                 slice(valid_index_ranges[0][0], valid_index_ranges[0][1]),
@@ -125,7 +134,7 @@ class OperationEDAXStateHandler:
         index0_range: tuple[int, int] | None = None,
         index1_range: tuple[int, int] | None = None,
         chunking_index: int = 0,
-        chunksize: int = 32,
+        chunksize: int = _DEFAULT_CHUNKSIZE,
     ) -> raveledImage:
         result = self.get_multi_channel_intensity_image(
             sample_name,
@@ -147,7 +156,7 @@ class OperationEDAXStateHandler:
         index0_range: tuple[int, int] | None = None,
         index1_range: tuple[int, int] | None = None,
         chunking_index: int = 0,
-        chunksize: int = 32,
+        chunksize: int = _DEFAULT_CHUNKSIZE,
     ) -> npt.NDArray[np.int64]:
 
         self._require_sample(sample_name)
@@ -163,7 +172,6 @@ class OperationEDAXStateHandler:
 
         index_offsets = [indx[0] for indx in index_ranges[:-1]]
         im_output = np.zeros(final_shape, dtype=np.int64)
-
         assert im_output.ndim == 2
 
         # prepare channel slice once
@@ -187,8 +195,11 @@ class OperationEDAXStateHandler:
 
             # Sum directly from the memmap along the channel axis using
             # numpy's accumulation dtype to avoid creating large int64 copies.
+            if edax_ds.data is None:
+                msg = f"data is None for sample {sample_name}"
+                raise ValueError(msg)
             im_subset = np.sum(edax_ds.data[data_slices], axis=-1, dtype=np.int64)
-
+            im_subset = im_subset.astype(np.int64).copy()
             slcs = [
                 slice(
                     index_ranges[idim][0] - index_offsets[idim],
@@ -196,11 +207,8 @@ class OperationEDAXStateHandler:
                 )
                 for idim in range(2)
             ]
-
-            im_output[slcs[0], slcs[1]] += im_subset
-
+            im_output[slcs[0], slcs[1]] = im_output[slcs[0], slcs[1]] + im_subset
             i_chunk_0 += chunksize
-
         return im_output
 
     def get_spectrum(
@@ -210,7 +218,7 @@ class OperationEDAXStateHandler:
         index0_range: tuple[int, int] | None = None,
         index1_range: tuple[int, int] | None = None,
         chunking_index: int = 0,
-        chunksize: int = 32,
+        chunksize: int = _DEFAULT_CHUNKSIZE,
     ) -> Spectrum1d:
 
         self._require_sample(sample_name)
@@ -231,6 +239,7 @@ class OperationEDAXStateHandler:
         assert im_output.ndim == 1
 
         i_chunk_0 = orig_ranges[chunking_index][0]
+        edax_ds = self.ph.load_edax(sample_name)
         while i_chunk_0 < orig_ranges[chunking_index][1]:
             i_chunk_1 = i_chunk_0 + chunksize
             i_chunk_1 = min(i_chunk_1, orig_ranges[chunking_index][1])
@@ -242,6 +251,7 @@ class OperationEDAXStateHandler:
                 index_ranges[2],
                 index0_range=index_ranges[0],
                 index1_range=index_ranges[1],
+                edax_ds=edax_ds,
             )
 
             im_reduced = im.sum(axis=0).sum(axis=0)
@@ -269,11 +279,14 @@ class OperationEDAXStateHandler:
 
     def get_combined_metadata(self, sample_name: str) -> CombinedMetadata:
         self._require_sample(sample_name)
-        fl = self.ph.load_edax(sample_name, metadata_only=True)
+        fl = self.ph.load_edax(sample_name, metadata_only=False)
         mm = fl.refined_metadata
 
         axes = fl.axes_by_index
-        shp = tuple(axes[axid].size for axid in range(3))
+        if fl.data is None:
+            msg = f"data is None for sample {sample_name}"
+            raise ValueError(msg)
+        shp = fl.data.shape
         assert len(shp) == 3
 
         return CombinedMetadata(metadata=mm, axes_by_index=axes, data_shape=shp)

--- a/packages/spectra_inspector_server/src/spectra_inspector_server/tests/test_mock_data.py
+++ b/packages/spectra_inspector_server/src/spectra_inspector_server/tests/test_mock_data.py
@@ -12,4 +12,7 @@ def test_createEDAXMock(im_shape: None | tuple[int, int, int]) -> None:
     for indx in range(3):
         ra_indx = ds.axes[indx].index_in_array
         sz = ds.axes[indx].size
+        if ds.data is None:
+            msg = "no data"
+            raise ValueError(msg)
         assert ds.data.shape[ra_indx] == sz


### PR DESCRIPTION
avoid dask use for now at least: use a lazy read to extract metadata, then build a plain np.memmap again.