### PR TITLE
warn and skip on duplicate dataset keys instead of erroring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,9 +87,11 @@ Data source is a filesystem scan, not a real database:
   `OnDiskDatabase` (`_database/on_disk_db.py`).
 - `OnDiskDatabase` recursively walks `SPECTRA_INSPECTOR_DATA_ROOT` for `.spd`
   files that have sibling `.spc`/`.ipr` (required) plus optional `.bmp`/`.xml`,
-  keyed by **file basename, which must be globally unique** across the tree.
-  Rescanning only happens via `/available-datasets?refresh_db=true` and only
-  when `SPECTRA_INSPECTOR_ALLOW_DB_REFRESH=true`.
+  keyed by **file basename**; a basename seen a second time anywhere in the tree
+  is skipped with a warning (`OnDiskDatabase.add_fileset` returns False), so the
+  first one found wins rather than the scan erroring out. Rescanning only
+  happens via `/available-datasets?refresh_db=true` and only when
+  `SPECTRA_INSPECTOR_ALLOW_DB_REFRESH=true`.
 - `SPECTRA_INSPECTOR_DESKTOP_MODE=true` skips that startup walk entirely
   (`dependencies.get_database_session` passes `init_db=False`) and enables
   `/browse-directory` + `/datasets-in-directory`, which let a client walk the

--- a/packages/spectra_inspector_server/README.md
+++ b/packages/spectra_inspector_server/README.md
@@ -56,8 +56,11 @@ basename.xml
 
 - the `.spd`, `.spc` and `.ipr` must be present for a file set to be added to
   the available datasets; the `.bmp` and `.xml` are optional.
-- file basenames must be unique across directories, unless
-  `SPECTRA_INSPECTOR_DB_ALLOW_MIXED_BASENAMES` is enabled (see below)
+- file sets are keyed by basename, so basenames should be unique across
+  directories: when the same basename is found a second time, the later file set
+  is skipped with a warning and only the first one found is available. Enabling
+  `SPECTRA_INSPECTOR_DB_ALLOW_MIXED_BASENAMES` (see below) keys by full path
+  instead, avoiding the collision entirely.
 - filesets may reside in any nested file structure (to the recursion limit of
   python)
 

--- a/packages/spectra_inspector_server/src/spectra_inspector_server/_database/on_disk_db.py
+++ b/packages/spectra_inspector_server/src/spectra_inspector_server/_database/on_disk_db.py
@@ -83,7 +83,6 @@ class OnDiskDatabase:
             self,
             allow_mixed_basenames=self.allow_mixed_basenames,
             recursive=recursive,
-            skip_duplicates=True,
         )
         # prefer a metadata csv alongside the data, fall back to the one at the
         # data root.
@@ -104,17 +103,32 @@ class OnDiskDatabase:
 
     def add_fileset(
         self, basename: str, files: dict[str, Path] | EDAX_file_set
-    ) -> None:
-        if basename in self.available_maps:
-            msg = f"Duplicate map name! {basename} exists already."
-            raise KeyError(msg)
+    ) -> bool:
+        """Register a fileset under ``basename``.
 
+        Returns True when the fileset was added, False when ``basename`` is
+        already registered (in which case the new fileset is skipped and a
+        warning is emitted).
+        """
         if not isinstance(files, EDAX_file_set):
             new_set = EDAX_file_set(**files)
         else:
             new_set = files
+
+        existing = self.available_maps.get(basename)
+        if existing is not None:
+            spectraLogger.warning(
+                "Duplicate map name! Skipping %s, the name %s is already "
+                "registered for %s.",
+                new_set.spd,
+                basename,
+                existing.spd,
+            )
+            return False
+
         spectraLogger.debug(f"adding {basename} to available_maps")
         self.available_maps[basename] = new_set
+        return True
 
     @property
     def sample_metadata_mapper(self) -> SampleMetadataMapper | None:
@@ -174,7 +188,6 @@ def _recursive_inspection(
     allow_mixed_basenames: bool = False,
     progress: InspectionProgress | None = None,
     recursive: bool = True,
-    skip_duplicates: bool = False,
 ) -> None:
     if progress is None:
         progress = InspectionProgress()
@@ -207,16 +220,8 @@ def _recursive_inspection(
             else:
                 basename = edax_set.spd.stem
 
-            if skip_duplicates and basename in db.available_maps:
-                spectraLogger.warning(
-                    "Skipping %s, a dataset named %s is already registered",
-                    edax_set.spd,
-                    basename,
-                )
-                continue
-
-            db.add_fileset(basename, edax_set)
-            progress.datasets_found += 1
+            if db.add_fileset(basename, edax_set):
+                progress.datasets_found += 1
 
         # go deeper if needed
         if recursive:
@@ -227,7 +232,6 @@ def _recursive_inspection(
                     allow_mixed_basenames=allow_mixed_basenames,
                     progress=progress,
                     recursive=recursive,
-                    skip_duplicates=skip_duplicates,
                 )
 
 

--- a/packages/spectra_inspector_server/src/spectra_inspector_server/tests/test_on_disk_db.py
+++ b/packages/spectra_inspector_server/src/spectra_inspector_server/tests/test_on_disk_db.py
@@ -1,0 +1,55 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from spectra_inspector_server._database.on_disk_db import get_expected_files
+from spectra_inspector_server._file_tree_handling import EDAXPathHandler
+
+
+def _write_edax_set(directory: Path, basename: str) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    for sample_file in get_expected_files(directory / (basename + ".spd")).values():
+        sample_file.write_text(f"writing to {sample_file}")
+
+
+@pytest.fixture
+def root_with_duplicates(tmp_path: Path) -> Path:
+    root = tmp_path / "data_root"
+    _write_edax_set(root / "session-a", "C-1")
+    _write_edax_set(root / "session-a", "C-2")
+    _write_edax_set(root / "session-b", "C-1")
+    _write_edax_set(root / "session-b" / "nested", "C-1")
+    return root
+
+
+def test_duplicate_basename_warns_and_skips(
+    root_with_duplicates: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.WARNING):
+        ph = EDAXPathHandler(root_with_duplicates, init_db=True)
+
+    # the first C-1 encountered wins, the other two are skipped (which of the
+    # three that is depends on directory iteration order)
+    assert set(ph.database.available_maps) == {"C-1", "C-2"}
+    assert ph.database.available_maps["C-1"].spd.name == "C-1.spd"
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 2
+    assert all("Duplicate map name" in w for w in warnings)
+
+
+def test_duplicate_basename_in_working_directory(root_with_duplicates: Path) -> None:
+    ph = EDAXPathHandler(root_with_duplicates, init_db=False)
+    ph.set_working_directory(root_with_duplicates / "session-b")
+    assert set(ph.database.available_maps) == {"C-1"}
+
+
+def test_add_fileset_return_value(tmp_path: Path) -> None:
+    _write_edax_set(tmp_path, "C-1")
+    ph = EDAXPathHandler(tmp_path, init_db=False)
+    files = get_expected_files(tmp_path / "C-1.spd")
+
+    assert ph.database.add_fileset("C-1", files) is True
+    assert ph.database.add_fileset("C-1", files) is False
+    assert len(ph.database.available_maps) == 1


### PR DESCRIPTION
Closes #95. A recursive scan that found the same basename twice raised KeyError out of OnDiskDatabase.add_fileset, aborting the whole walk. The duplicate check now lives in add_fileset itself, which logs a warning, skips the later file set and returns False. This makes the previous skip_duplicates flag (only set by set_working_directory) redundant.