### PR TITLE
show the real data root and clearer dataset counts when browsing

### DIFF
--- a/packages/spectra_inspector/src/spectra_inspector/components/directory_selector.py
+++ b/packages/spectra_inspector/src/spectra_inspector/components/directory_selector.py
@@ -89,11 +89,35 @@ def desktop_mode_enabled() -> bool:
     return Settings().desktop_mode
 
 
-def path_label(path: str | None) -> str:
-    """Human readable form of a path relative to the server data root."""
-    if not path:
+def data_root_label(sisi: SpectraInspectorServerInterface | None = None) -> str:
+    """What to call the top of the browsable tree.
+
+    A desktop deployment points at a data root the user chose themselves, so
+    spelling it out is more useful than a placeholder -- and it is the only way
+    to tell which root a relative path is relative to. Elsewhere the data root
+    is a server-side detail, so the placeholder stands in for it.
+    """
+    if not desktop_mode_enabled():
         return DATA_ROOT_LABEL
-    return f"{DATA_ROOT_LABEL}/{path}"
+
+    if sisi is None:
+        sisi = SpectraInspectorServerInterface()
+
+    try:
+        info = sisi.get_info()
+    except ServerRequestError as err:
+        spectraLogger.warning(f"Could not fetch the server data root: {err}")
+        return DATA_ROOT_LABEL
+
+    return info.spectra_inspector_data_root or DATA_ROOT_LABEL
+
+
+def path_label(path: str | None, root: str | None = None) -> str:
+    """Human readable form of a path relative to the server data root."""
+    root_label = root or DATA_ROOT_LABEL
+    if not path:
+        return root_label
+    return f"{root_label.rstrip('/')}/{path}"
 
 
 def parent_path(path: str | None) -> str | None:
@@ -183,7 +207,7 @@ def directory_selector(
                     [
                         html.Div("Working directory: ", className="fw-bold"),
                         html.Div(
-                            path_label(""),
+                            path_label("", root=data_root_label()),
                             id=IDS.get_id_with_index("path"),
                             style={"wordBreak": "break-all"},
                         ),
@@ -336,25 +360,30 @@ def show_directory_listing(browse_data: dict | None):
         msg = "Could not connect to spectra_inspector_server backend."
         return path_label(path), [], at_root, html.Div(msg)
 
+    root = data_root_label(sisi)
+
     try:
         listing = sisi.browse_directory(path)
     except ServerRequestError as err:
         spectraLogger.warning(f"Could not browse '{path}': {err}")
-        return path_label(path), [], at_root, html.Div(str(err))
+        return path_label(path, root=root), [], at_root, html.Div(str(err))
 
     n_sets = listing.dataset_count
     plural = "" if n_sets == 1 else "s"
-    status = f"{n_sets} dataset{plural} directly in this directory."
+    status = (
+        f"{n_sets} dataset{plural} in this directory. "
+        'Click "Use this directory" to search the subdirectories.'
+    )
 
     return (
-        path_label(listing.path),
+        path_label(listing.path, root=root),
         _subdir_items(listing, component_index),
         listing.parent_path is None,
         html.Div(status),
     )
 
 
-def _scan_status(path: str, available) -> html.Div:
+def _scan_status(path: str, available, root: str) -> html.Div:
     """The message shown after committing a directory.
 
     A truncated scan is called out explicitly: the server stopped at its
@@ -365,14 +394,15 @@ def _scan_status(path: str, available) -> html.Div:
 
     n_files = len(available.available_files)
     plural = "" if n_files == 1 else "s"
+    label = path_label(path, root=root)
 
     if not available.truncated:
-        return html.Div(f"Loaded {n_files} dataset{plural} from {path_label(path)}.")
+        return html.Div(f"Loaded {n_files} dataset{plural} from {label}.")
 
     return html.Div(
         [
             html.Div(
-                f"Showing the first {n_files} dataset{plural} in {path_label(path)}.",
+                f"Showing the first {n_files} dataset{plural} in {label}.",
                 className="fw-bold",
             ),
             html.Div(
@@ -427,7 +457,7 @@ def use_directory(n_clicks: int, browse_data: dict | None, recursive: bool):
 
     return (
         format_selections(["none", *available_files]),
-        _scan_status(path, available),
+        _scan_status(path, available, data_root_label(sisi)),
         {
             "path": path,
             "available_files": available_files,

--- a/packages/spectra_inspector/src/spectra_inspector/components/directory_selector.py
+++ b/packages/spectra_inspector/src/spectra_inspector/components/directory_selector.py
@@ -20,7 +20,11 @@ from spectra_inspector.components.dataset_selector import (
 from spectra_inspector.components.layout_ids import indexedLayoutIDMapper
 from spectra_inspector.logging import spectraLogger
 from spectra_inspector.settings import Settings
-from spectra_inspector.user_store_model import USER_STORE_DIV_ID, updateDataStore
+from spectra_inspector.user_store_model import (
+    USER_STORE_DIV_ID,
+    UserStore,
+    updateDataStore,
+)
 from spectra_inspector.utilities.interface import (
     ServerRequestError,
     SpectraInspectorServerInterface,
@@ -335,15 +339,86 @@ def hydrate_browse_position(_div_id: dict, user_data: dict | None):
     return {"path": (user_data or {}).get("working_directory") or ""}
 
 
+def loaded_status(n_datasets: int, label: str, truncated: bool = False) -> html.Div:
+    """The message shown for a directory that has been scanned into the server.
+
+    A truncated scan is called out explicitly: the server stopped at its
+    SPECTRA_INSPECTOR_MAX_DATASETS limit, so the dropdown holds the first N of
+    an unknown larger number and the missing ones are only reachable by picking
+    a narrower directory.
+    """
+
+    plural = "" if n_datasets == 1 else "s"
+
+    if not truncated:
+        return html.Div(f"Loaded {n_datasets} dataset{plural} from {label}.")
+
+    return html.Div(
+        [
+            html.Div(
+                f"Showing the first {n_datasets} dataset{plural} in {label}.",
+                className="fw-bold",
+            ),
+            html.Div(
+                "The server stopped scanning at its dataset limit, so this "
+                "directory holds more than are listed. Pick a subdirectory to "
+                "reach the rest.",
+            ),
+        ],
+        className="text-warning",
+    )
+
+
+def browse_status(n_datasets: int, has_subdirectories: bool) -> str:
+    """What a directory that is only being browsed reports.
+
+    The count is of this directory alone, which read as though it covered the
+    whole subtree, so point at the button that does search the subtree -- but
+    only where there is a subtree to search.
+    """
+    plural = "" if n_datasets == 1 else "s"
+    status = f"{n_datasets} dataset{plural} in this directory."
+    if has_subdirectories:
+        status += ' Click "Use this directory" to search the subdirectories.'
+    return status
+
+
+def committed_status(path: str, user_data: dict | None, root: str) -> html.Div | None:
+    """The "loaded" message for `path`, or None if it is not the directory in
+    use.
+
+    Rebuilt from the user store rather than remembered per mount: the status
+    div is page-local, so the message `use_directory` wrote on one page is gone
+    by the time the other page's picker mounts, the same way the browse
+    position is. The store holds the working directory and what was found in
+    it, which is everything the message needs.
+    """
+
+    store = UserStore(**(user_data or {}))
+    if store.available_files is None or (store.working_directory or "") != path:
+        return None
+    return loaded_status(
+        len(store.available_files),
+        path_label(path, root=root),
+        truncated=store.truncated,
+    )
+
+
 @callback(
     Output({"type": _IDS.path, "index": MATCH}, "children"),
     Output({"type": _IDS.entries, "index": MATCH}, "children"),
     Output({"type": _IDS.up, "index": MATCH}, "disabled"),
     Output({"type": _IDS.status, "index": MATCH}, "children"),
     Input({"type": _IDS.browsestore, "index": MATCH}, "data"),
+    State(USER_STORE_DIV_ID, "data"),
 )
-def show_directory_listing(browse_data: dict | None):
-    """Fetch the listing for the current browse position and render it."""
+def show_directory_listing(browse_data: dict | None, user_data: dict | None):
+    """Fetch the listing for the current browse position and render it.
+
+    The user store is a State rather than an Input: it is read to restore the
+    status message on a fresh mount, and re-fetching the listing every time
+    something else writes the store would be a round trip for nothing.
+    """
 
     if browse_data is None:
         # mounted but not hydrated yet; `hydrate_browse_position` fires this
@@ -368,50 +443,15 @@ def show_directory_listing(browse_data: dict | None):
         spectraLogger.warning(f"Could not browse '{path}': {err}")
         return path_label(path, root=root), [], at_root, html.Div(str(err))
 
-    n_sets = listing.dataset_count
-    plural = "" if n_sets == 1 else "s"
-    status = (
-        f"{n_sets} dataset{plural} in this directory. "
-        'Click "Use this directory" to search the subdirectories.'
+    status = committed_status(listing.path, user_data, root) or html.Div(
+        browse_status(listing.dataset_count, bool(listing.directories))
     )
 
     return (
         path_label(listing.path, root=root),
         _subdir_items(listing, component_index),
         listing.parent_path is None,
-        html.Div(status),
-    )
-
-
-def _scan_status(path: str, available, root: str) -> html.Div:
-    """The message shown after committing a directory.
-
-    A truncated scan is called out explicitly: the server stopped at its
-    SPECTRA_INSPECTOR_MAX_DATASETS limit, so the dropdown holds the first N of
-    an unknown larger number and the missing ones are only reachable by picking
-    a narrower directory.
-    """
-
-    n_files = len(available.available_files)
-    plural = "" if n_files == 1 else "s"
-    label = path_label(path, root=root)
-
-    if not available.truncated:
-        return html.Div(f"Loaded {n_files} dataset{plural} from {label}.")
-
-    return html.Div(
-        [
-            html.Div(
-                f"Showing the first {n_files} dataset{plural} in {label}.",
-                className="fw-bold",
-            ),
-            html.Div(
-                "The server stopped scanning at its dataset limit, so this "
-                "directory holds more than are listed. Pick a subdirectory to "
-                "reach the rest.",
-            ),
-        ],
-        className="text-warning",
+        status,
     )
 
 
@@ -455,13 +495,16 @@ def use_directory(n_clicks: int, browse_data: dict | None, recursive: bool):
     available_files = available.available_files
     spectraLogger.info(f"'{path}' provided {len(available_files)} datasets")
 
+    label = path_label(path, root=data_root_label(sisi))
+
     return (
         format_selections(["none", *available_files]),
-        _scan_status(path, available, data_root_label(sisi)),
+        loaded_status(len(available_files), label, truncated=available.truncated),
         {
             "path": path,
             "available_files": available_files,
             "sample_metadata": available.sample_metadata,
+            "truncated": available.truncated,
         },
     )
 
@@ -505,6 +548,9 @@ def store_working_directory(
     )
     new_user_data = updateDataStore(
         new_user_data, "sample_metadata", payload.get("sample_metadata")
+    )
+    new_user_data = updateDataStore(
+        new_user_data, "truncated", bool(payload.get("truncated"))
     )
     # the previous selection came from a directory that is no longer loaded
     new_user_data = updateDataStore(new_user_data, "selected_dataset", "none")

--- a/packages/spectra_inspector/src/spectra_inspector/components/tests/test_directory_selector.py
+++ b/packages/spectra_inspector/src/spectra_inspector/components/tests/test_directory_selector.py
@@ -8,6 +8,7 @@ from dash._utils import AttributeDict
 # the components package re-exports the directory_selector *function* under the
 # module's own name, so these have to come off the module path directly.
 from spectra_inspector.components.directory_selector import (
+    data_root_label,
     directory_selector,
     directorySelectorLayoutIDs,
     entry_id,
@@ -109,6 +110,66 @@ def test_path_label(path, expected):
 
 
 @pytest.mark.parametrize(
+    ("root", "path", "expected"),
+    [
+        ("/data/edax", "", "/data/edax"),
+        ("/data/edax", "a/b", "/data/edax/a/b"),
+        # a root spelled with a trailing separator must not double it up
+        ("/data/edax/", "a", "/data/edax/a"),
+        ("/", "a", "/a"),
+        # falls back to the placeholder when there is no root to show
+        ("", "a", "<data root>/a"),
+    ],
+)
+def test_path_label_with_a_root(root, path, expected):
+    assert path_label(path, root=root) == expected
+
+
+def _mock_settings(mocker, desktop_mode: bool) -> None:
+    mocker.patch(
+        "spectra_inspector.components.directory_selector.desktop_mode_enabled",
+        mocker.MagicMock(return_value=desktop_mode),
+    )
+
+
+def test_data_root_label_outside_desktop_mode(mocker):
+    # the data root is a server-side detail that a hosted client should not show
+    _mock_settings(mocker, False)
+    sisi = mocker.MagicMock()
+
+    assert data_root_label(sisi) == "<data root>"
+    sisi.get_info.assert_not_called()
+
+
+def test_data_root_label_in_desktop_mode(mocker):
+    _mock_settings(mocker, True)
+    info = mocker.MagicMock(spectra_inspector_data_root="/data/edax")
+    sisi = mocker.MagicMock(get_info=mocker.MagicMock(return_value=info))
+
+    assert data_root_label(sisi) == "/data/edax"
+
+
+@pytest.mark.parametrize(
+    "get_info",
+    [
+        pytest.param(ServerRequestError("no backend"), id="request-failed"),
+        pytest.param("", id="empty-root"),
+    ],
+)
+def test_data_root_label_falls_back_to_the_placeholder(mocker, get_info):
+    _mock_settings(mocker, True)
+    if isinstance(get_info, ServerRequestError):
+        mocked = mocker.MagicMock(side_effect=get_info)
+    else:
+        mocked = mocker.MagicMock(
+            return_value=mocker.MagicMock(spectra_inspector_data_root=get_info)
+        )
+    sisi = mocker.MagicMock(get_info=mocked)
+
+    assert data_root_label(sisi) == "<data root>"
+
+
+@pytest.mark.parametrize(
     ("path", "expected"),
     [(None, None), ("", None), ("a", ""), ("a/b", "a"), ("a/b/c", "a/b")],
 )
@@ -200,7 +261,24 @@ def test_show_directory_listing(mocker):
     assert [e.id["name"] for e in entries] == ["session-a/nested"]
     assert [e.children for e in entries] == ["nested"]
     assert up_disabled is False
-    assert "1 dataset directly" in status.children
+    assert "1 dataset in this directory" in status.children
+    # the hint that "use this directory" is what reaches the subdirectories
+    assert "subdirectories" in status.children
+
+
+def test_show_directory_listing_shows_the_real_root_in_desktop_mode(mocker):
+    _mock_settings(mocker, True)
+    info = mocker.MagicMock(spectra_inspector_data_root="/data/edax")
+    _mock_interface(
+        mocker,
+        browse_directory=mocker.MagicMock(return_value=_LISTING),
+        get_info=mocker.MagicMock(return_value=info),
+    )
+    _set_outputs_for_index(0)
+
+    label, _, _, _ = show_directory_listing({"path": "session-a"})
+
+    assert label == "/data/edax/session-a"
 
 
 def test_show_directory_listing_uses_the_matched_index(mocker):
@@ -226,7 +304,7 @@ def test_show_directory_listing_with_no_subdirectories(mocker):
     assert entries[0].disabled is True
     assert not hasattr(entries[0], "name")
     assert up_disabled is False
-    assert "3 datasets directly" in status.children
+    assert "3 datasets in this directory" in status.children
 
 
 def test_show_directory_listing_at_the_data_root(mocker):
@@ -240,7 +318,7 @@ def test_show_directory_listing_at_the_data_root(mocker):
     assert len(entries) == 1
     assert entries[0].disabled is True
     assert up_disabled is True
-    assert "0 datasets directly" in status.children
+    assert "0 datasets in this directory" in status.children
 
 
 def test_show_directory_listing_reports_server_errors(mocker):
@@ -290,6 +368,22 @@ def test_use_directory_populates_the_sample_dropdown(mocker):
         "available_files": ["C-1", "C-2"],
         "sample_metadata": {"records": [], "map_samples": {}},
     }
+
+
+def test_use_directory_reports_the_real_root_in_desktop_mode(mocker):
+    _mock_settings(mocker, True)
+    info = mocker.MagicMock(spectra_inspector_data_root="/data/edax")
+    _mock_interface(
+        mocker,
+        get_datasets_in_directory=mocker.MagicMock(
+            return_value=AvailableDatasets(available_files=["C-1"])
+        ),
+        get_info=mocker.MagicMock(return_value=info),
+    )
+
+    _, status, _ = use_directory(1, {"path": "session-a"}, True)
+
+    assert "from /data/edax/session-a." in status.children
 
 
 def test_use_directory_passes_the_recursive_flag(mocker):

--- a/packages/spectra_inspector/src/spectra_inspector/components/tests/test_directory_selector.py
+++ b/packages/spectra_inspector/src/spectra_inspector/components/tests/test_directory_selector.py
@@ -42,6 +42,15 @@ def _clear_context():
     context_value.set(AttributeDict(triggered_inputs=[]))
 
 
+@pytest.fixture(autouse=True)
+def _desktop_mode_off(mocker):
+    # `data_root_label` reads Settings(), so these would otherwise depend on
+    # whether the developer's .env happens to switch desktop mode on -- CI has
+    # no .env and passes either way. The tests that want it on re-patch over
+    # this with `_mock_settings`.
+    _mock_settings(mocker, False)
+
+
 def test_directory_selector_layout_ids():
     ids = directorySelectorLayoutIDs(index=0)
     for prop in ids.prop_names:
@@ -92,7 +101,7 @@ def test_show_directory_listing_waits_for_hydration(mocker):
     sisi = _mock_interface(mocker, browse_directory=mocker.MagicMock())
     _set_outputs_for_index(0)
 
-    assert all(out is no_update for out in show_directory_listing(None))
+    assert all(out is no_update for out in show_directory_listing(None, None))
     sisi.browse_directory.assert_not_called()
 
 
@@ -255,7 +264,9 @@ def test_show_directory_listing(mocker):
     _mock_interface(mocker, browse_directory=mocker.MagicMock(return_value=_LISTING))
     _set_outputs_for_index(0)
 
-    label, entries, up_disabled, status = show_directory_listing({"path": "session-a"})
+    label, entries, up_disabled, status = show_directory_listing(
+        {"path": "session-a"}, None
+    )
 
     assert label == "<data root>/session-a"
     assert [e.id["name"] for e in entries] == ["session-a/nested"]
@@ -276,7 +287,7 @@ def test_show_directory_listing_shows_the_real_root_in_desktop_mode(mocker):
     )
     _set_outputs_for_index(0)
 
-    label, _, _, _ = show_directory_listing({"path": "session-a"})
+    label, _, _, _ = show_directory_listing({"path": "session-a"}, None)
 
     assert label == "/data/edax/session-a"
 
@@ -287,7 +298,7 @@ def test_show_directory_listing_uses_the_matched_index(mocker):
     _mock_interface(mocker, browse_directory=mocker.MagicMock(return_value=_LISTING))
     _set_outputs_for_index(1)
 
-    _, entries, _, _ = show_directory_listing({"path": "session-a"})
+    _, entries, _, _ = show_directory_listing({"path": "session-a"}, None)
 
     assert [e.id["index"] for e in entries] == [1]
 
@@ -297,14 +308,15 @@ def test_show_directory_listing_with_no_subdirectories(mocker):
     _mock_interface(mocker, browse_directory=mocker.MagicMock(return_value=leaf))
     _set_outputs_for_index(0)
 
-    _, entries, up_disabled, status = show_directory_listing({"path": "a"})
+    _, entries, up_disabled, status = show_directory_listing({"path": "a"}, None)
 
     # a placeholder row, and crucially nothing carrying a clickable id
     assert len(entries) == 1
     assert entries[0].disabled is True
     assert not hasattr(entries[0], "name")
     assert up_disabled is False
-    assert "3 datasets in this directory" in status.children
+    # nothing to search, so no pointer at the button that would search it
+    assert status.children == "3 datasets in this directory."
 
 
 def test_show_directory_listing_at_the_data_root(mocker):
@@ -312,7 +324,7 @@ def test_show_directory_listing_at_the_data_root(mocker):
     _mock_interface(mocker, browse_directory=mocker.MagicMock(return_value=root))
     _set_outputs_for_index(0)
 
-    label, entries, up_disabled, status = show_directory_listing({"path": ""})
+    label, entries, up_disabled, status = show_directory_listing({"path": ""}, None)
 
     assert label == "<data root>"
     assert len(entries) == 1
@@ -321,12 +333,78 @@ def test_show_directory_listing_at_the_data_root(mocker):
     assert "0 datasets in this directory" in status.children
 
 
+_COMMITTED_STORE = {
+    "working_directory": "session-a",
+    "available_files": ["C-1", "C-2"],
+}
+
+
+def test_show_directory_listing_restores_the_committed_count(mocker):
+    # a fresh mount on the other page has no memory of the message
+    # `use_directory` wrote, but the user store still knows what was loaded
+    _mock_interface(mocker, browse_directory=mocker.MagicMock(return_value=_LISTING))
+    _set_outputs_for_index(1)
+
+    _, _, _, status = show_directory_listing({"path": "session-a"}, _COMMITTED_STORE)
+
+    assert status.children == "Loaded 2 datasets from <data root>/session-a."
+
+
+def test_show_directory_listing_counts_directories_that_are_not_in_use(mocker):
+    # browsing away from the committed directory goes back to the plain count
+    _mock_interface(mocker, browse_directory=mocker.MagicMock(return_value=_LISTING))
+    _set_outputs_for_index(0)
+
+    store = {**_COMMITTED_STORE, "working_directory": "session-b"}
+    _, _, _, status = show_directory_listing({"path": "session-a"}, store)
+
+    assert "1 dataset in this directory" in status.children
+
+
+def test_show_directory_listing_ignores_a_store_with_nothing_committed(mocker):
+    root = directoryListing(path="", name="root", parent_path=None, dataset_count=0)
+    _mock_interface(mocker, browse_directory=mocker.MagicMock(return_value=root))
+    _set_outputs_for_index(0)
+
+    # working_directory defaults to None, which reads as "" -- the data root --
+    # so it must be the missing available_files that rules a commit out
+    _, _, _, status = show_directory_listing({"path": ""}, {"selected_dataset": "none"})
+
+    assert "0 datasets in this directory" in status.children
+
+
+def test_show_directory_listing_restores_a_truncated_scan(mocker):
+    # the warning has to come back with the count, or a page switch quietly
+    # turns "showing the first N" into "loaded N"
+    _mock_interface(mocker, browse_directory=mocker.MagicMock(return_value=_LISTING))
+    _set_outputs_for_index(1)
+
+    store = {**_COMMITTED_STORE, "truncated": True}
+    _, _, _, status = show_directory_listing({"path": "session-a"}, store)
+
+    text = " ".join(child.children for child in status.children)
+    assert "first 2 datasets" in text
+    assert "Pick a subdirectory" in text
+    assert "text-warning" in status.className
+
+
+def test_show_directory_listing_restores_a_commit_at_the_data_root(mocker):
+    root = directoryListing(path="", name="root", parent_path=None, dataset_count=0)
+    _mock_interface(mocker, browse_directory=mocker.MagicMock(return_value=root))
+    _set_outputs_for_index(0)
+
+    store = {"working_directory": "", "available_files": ["C-1"]}
+    _, _, _, status = show_directory_listing({"path": ""}, store)
+
+    assert status.children == "Loaded 1 dataset from <data root>."
+
+
 def test_show_directory_listing_reports_server_errors(mocker):
     err = ServerRequestError("directory browsing requires DESKTOP_MODE")
     _mock_interface(mocker, browse_directory=mocker.MagicMock(side_effect=err))
     _set_outputs_for_index(0)
 
-    label, entries, up_disabled, status = show_directory_listing({"path": "a"})
+    label, entries, up_disabled, status = show_directory_listing({"path": "a"}, None)
 
     assert label == "<data root>/a"
     assert entries == []
@@ -341,7 +419,7 @@ def test_show_directory_listing_without_a_backend(mocker):
 
     _set_outputs_for_index(0)
 
-    _, entries, _, status = show_directory_listing({"path": ""})
+    _, entries, _, status = show_directory_listing({"path": ""}, None)
 
     assert entries == []
     assert "Could not connect" in status.children
@@ -367,6 +445,7 @@ def test_use_directory_populates_the_sample_dropdown(mocker):
         "path": "session-a",
         "available_files": ["C-1", "C-2"],
         "sample_metadata": {"records": [], "map_samples": {}},
+        "truncated": False,
     }
 
 

--- a/packages/spectra_inspector/src/spectra_inspector/user_store_model.py
+++ b/packages/spectra_inspector/src/spectra_inspector/user_store_model.py
@@ -18,6 +18,10 @@ class UserStore:
     # stay None when the server scans its whole data root at startup.
     working_directory: str | None = None
     available_files: list[str] | None = None
+    # true when the server stopped that scan at its dataset limit, so
+    # available_files is the first N of a larger number on disk. Kept here so a
+    # picker mounting on the other page can repeat the warning.
+    truncated: bool = False
 
     def get_metadata(self) -> CombinedMetadata | None:
         if self.metadata_json != "":

--- a/packages/spectra_inspector/src/spectra_inspector/utilities/interface.py
+++ b/packages/spectra_inspector/src/spectra_inspector/utilities/interface.py
@@ -68,7 +68,12 @@ class SpectraInspectorServerInterface:
 
     def get_info(self) -> model.Info:
         uri = self._get_endpoint("info")
-        r = requests.get(uri)
+        try:
+            r = requests.get(uri)
+        except requests.exceptions.ConnectionError as err:
+            msg = f"could not reach the backend at {self.uri}"
+            raise ServerRequestError(msg) from err
+        _raise_for_status(r)
         return model.Info(**r.json())
 
     def get_available_datasets(


### PR DESCRIPTION
The directory picker labelled every path against a "<data root>" placeholder. In desktop mode the data root is a directory the user picked themselves, so spell it out (fetched from the server's /info endpoint) -- it is the only way to tell which root a relative path hangs off. Outside desktop mode the root stays a server-side detail and keeps the placeholder.

The dataset count also read as if it covered the whole subtree, so say that "Use this directory" is what reaches the subdirectories.

Closes #94